### PR TITLE
Avoid lint error: no-template-curly-in-string

### DIFF
--- a/generator/index.js
+++ b/generator/index.js
@@ -125,7 +125,7 @@ module.exports = (api, opts, rootOpts) => {
           'transform-imports',
           {
             vuetify: {
-              transform: 'vuetify/es5/components/${member}',
+              transform: 'vuetify/es5/components/${' + 'member}',
               preventFullImport: true
             }
           }


### PR DESCRIPTION
This line causes lint errors:

https://github.com/vuetifyjs/vue-cli-plugin-vuetify/edit/dev/generator/index.js#L128

`'transform': 'vuetify/es5/components/${member}',`