### PR TITLE
Use chainWebpack instead of configureWebpack to add Loader plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,10 +12,9 @@ module.exports = (api) => {
         .rule('js')
         .include
           .add(api.resolve('node_modules/vuetify'))
-    })
-
-    api.configureWebpack(webpackConfig => {
-      webpackConfig.plugins.push(new VuetifyLoaderPlugin())
+      
+      config.plugin('VuetifyLoaderPlugin')
+        .use(VuetifyLoaderPlugin)
     })
   }
 }


### PR DESCRIPTION
This is a better practice since now end users can use the `chainWepack` API to access this plugin, e.g. to remove it, or pass options to it once (if ever) the plugin supports that.

I realize that this is not a very significant change for the moment but as a general rule it's better to use chainWebpack as a plugin author to give the maximum control over the resulting config to the end user.