### PR TITLE
Fix issue #55

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-module.exports = (api) => {
+const path = require('path');
+module.exports = (api, opts) => {
   const hasVuetifyLoader = Boolean(
     api.service.pkg.devDependencies['vuetify-loader'] ||
     api.service.pkg.dependencies['vuetify-loader']
@@ -7,9 +8,20 @@ module.exports = (api) => {
   if (hasVuetifyLoader) {
     const VuetifyLoaderPlugin = require('vuetify-loader/lib/plugin')
 
+    // As the vuetify-loader automatically imports the necessary Vuetify components they are not found and
+    // transpiled by Babel. Add Vuetify explicitly as a module to be transpiled.
+    // Warn we have "vuetify" as a string we show a warning message
+    if (opts.transpileDependencies.includes("vuetify")) {
+      console.warn("WARN: The string 'vuetify' shoud not be used as an option for 'transpileDependencies' in 'vue.config.js'. Visit https://github.com/vuetifyjs/vue-cli-plugin-vuetify/issues/55 to learn more.")
+    } else {
+      if (!opts.transpileDependencies.some(td => td.toString().includes('vuetify'))) {
+        opts.transpileDependencies.push(path.resolve(__dirname, '../vuetify/'))
+      }
+    }
+
     api.chainWebpack(config => {
-      config.plugin('VuetifyLoaderPlugin')
-        .use(VuetifyLoaderPlugin)
+    config.plugin('VuetifyLoaderPlugin')
+      .use(VuetifyLoaderPlugin)
     })
   }
 }


### PR DESCRIPTION
`transpileDependencies` is required to have Vuetify compiled when à-la-carte is used. This pull request adds it back (reference https://github.com/vuetifyjs/vue-cli-plugin-vuetify/issues/55#issuecomment-443185444)

However, we must not use `transpileDependencies: ['vuetify']` because https://github.com/vuejs/vue-cli/blob/dev/packages/%40vue/cli-plugin-babel/index.js#L26 will search the term `vuetify` in the full path, so if your project path is `/home/aymkdn/projects/vuetify/my-app/` then ALL files in this directory will be translated by Babel, causing multiple errors.

This PR will warn the people who already put  `transpileDependencies: ['vuetify']` in their `vue.config.js`.
If no references to `"vuetify"` is found, the full path to `vuetify` is provided to `transpileDependencies` (at first I thought to use a regular expression like `/[/\\]vuetify[/\\]/`, however if the path is at I described above, then you'll receive an error, so I changed it to use the full path to `vuetify`)

I'll also submit a PR to the Vuetify project to change the documentation, and also to the Vue-CLI project to discuss about this `transpileDependencies` option that may miss lead the users.