### PR TITLE
Support asset references from v-img

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,4 +12,17 @@ module.exports = (api) => {
         .use(VuetifyLoaderPlugin)
     })
   }
+  
+  // Resolve asset references from v-img
+  api.chainWebpack(config => {
+    config.module
+      .rule('vue')
+      .use('vue-loader')
+      .tap(options => ({
+        ...options,
+        transformAssetUrls: {
+          'v-img': 'src',
+        },
+      }))
+  })
 }

--- a/index.js
+++ b/index.js
@@ -21,6 +21,8 @@ module.exports = (api) => {
       .tap(options => ({
         ...options,
         transformAssetUrls: {
+          // v-carousel-item extends v-img
+          'v-carousel-item': ['src', 'lazy-src'],
           'v-img': ['src', 'lazy-src'],
           'v-parallax': 'src',
         },

--- a/index.js
+++ b/index.js
@@ -21,10 +21,13 @@ module.exports = (api) => {
       .tap(options => ({
         ...options,
         transformAssetUrls: {
+          // v-app-bar extends v-toolbar
+          'v-app-bar': 'src',
           // v-carousel-item extends v-img
           'v-carousel-item': ['src', 'lazy-src'],
           'v-img': ['src', 'lazy-src'],
           'v-parallax': 'src',
+          'v-toolbar': 'src',
         },
       }))
   })

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = (api) => {
         .use(VuetifyLoaderPlugin)
     })
   }
-  
+
   // Resolve asset references from v-img
   api.chainWebpack(config => {
     config.module
@@ -21,7 +21,8 @@ module.exports = (api) => {
       .tap(options => ({
         ...options,
         transformAssetUrls: {
-          'v-img': 'src',
+          'v-img': ['src', 'lazy-src'],
+          'v-parallax': 'src',
         },
       }))
   })

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = (api) => {
     })
   }
 
-  // Resolve asset references from v-img
+  // Resolve asset references from components
   api.chainWebpack(config => {
     config.module
       .rule('vue')


### PR DESCRIPTION
`vue-loader` does not automatically `require` assets referenced in the `src` attribute of a [`<v-img>`](https://vuetifyjs.com/en/components/images) tag. This change makes `<v-img>` [work with `vue-loader`](https://vue-loader.vuejs.org/options.html#transformasseturls) in the same way that `<img>` does.

Template markup looking like `<v-img src="@/assets/logo.png">` will now compile properly.
