### PR TITLE
Fix loading when a dependencies key doesn't exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,10 @@
 module.exports = (api) => {
-  const hasVuetifyLoader = Boolean(
-    api.service.pkg.devDependencies['vuetify-loader'] ||
-    api.service.pkg.dependencies['vuetify-loader']
-  )
+  const VuetifyLoaderPlugin = require('vuetify-loader/lib/plugin')
 
-  if (hasVuetifyLoader) {
-    const VuetifyLoaderPlugin = require('vuetify-loader/lib/plugin')
-
-    api.chainWebpack(config => {
-      config.plugin('VuetifyLoaderPlugin')
-        .use(VuetifyLoaderPlugin)
-    })
-  }
+  api.chainWebpack(config => {
+    config.plugin('VuetifyLoaderPlugin')
+      .use(VuetifyLoaderPlugin)
+  })
 
   // Resolve asset references from components
   api.chainWebpack(config => {

--- a/index.js
+++ b/index.js
@@ -1,10 +1,21 @@
 module.exports = (api) => {
-  const VuetifyLoaderPlugin = require('vuetify-loader/lib/plugin')
-
-  api.chainWebpack(config => {
-    config.plugin('VuetifyLoaderPlugin')
-      .use(VuetifyLoaderPlugin)
-  })
+  // Require vuetify-loader if available
+  let VuetifyLoaderPlugin
+  try {
+    VuetifyLoaderPlugin = require('vuetify-loader/lib/plugin')
+  } catch (e){
+    // Only ignore cases where module doesn't exist
+    if (e.code !== 'MODULE_NOT_FOUND'){
+        throw e
+    }
+  }
+  
+  if (VuetifyLoaderPlugin) {
+    api.chainWebpack(config => {
+      config.plugin('VuetifyLoaderPlugin')
+        .use(VuetifyLoaderPlugin)
+    })
+  }
 
   // Resolve asset references from components
   api.chainWebpack(config => {


### PR DESCRIPTION
This package requires both dependencies and devDependencies to exist, else will fail to load. This is not a requirement in npm. vuetify-loader is also a dependency already so should be assumed to exist rather than testing for it.