### PR TITLE
fix: add support for sass-loader > 8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "vuetify-loader": "^1.2.2"
   },
   "dependencies": {
-    "shelljs": "^0.8.3"
+    "shelljs": "^0.8.3",
+    "semver": "^6.0.0"
   },
   "husky": {
     "hooks": {

--- a/util/__tests__/__snapshots__/helpers.spec.js.snap
+++ b/util/__tests__/__snapshots__/helpers.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`helpers.js should merge sass variable rules 1`] = `
 Object {
-  "data": "@import '@/sass/variables.sass'
+  "prependData": "@import '@/sass/variables.sass'
 @import '@/sass/variables.scss'
 @import '@/scss/variables.sass'
 @import '@/scss/variables.scss'
@@ -20,7 +20,7 @@ Object {
 
 exports[`helpers.js should merge sass variable rules 2`] = `
 Object {
-  "data": "@import '@/sass/variables.sass';
+  "prependData": "@import '@/sass/variables.sass';
 @import '@/sass/variables.scss';
 @import '@/scss/variables.sass';
 @import '@/scss/variables.scss';

--- a/util/helpers.js
+++ b/util/helpers.js
@@ -1,4 +1,5 @@
 // Imports
+const semver = require('semver')
 const fs = require('fs')
 
 // Check for existence of file and add import
@@ -46,7 +47,16 @@ function mergeRules (api, opt, ext) {
 
   addImports(api, 'lists', data, end)
 
-  opt.data = data.join('\n')
+  let sassLoaderVersion
+  try {
+    sassLoaderVersion = semver.major(require('sass-loader/package.json').version)
+  } catch (e) {}
+
+  if (sassLoaderVersion < 8) {
+    opt.data = data.join('\n')
+  } else {
+    opt.prependData = data.join('\n')
+  }
 
   return opt
 }


### PR DESCRIPTION
fixes https://github.com/vuetifyjs/vue-cli-plugin-vuetify/issues/119.

We should probably also install 8.0.0 in our generator (https://github.com/vuetifyjs/vue-cli-plugin-vuetify/blob/dev/generator/tools/alaCarte.js#L6) 
Since @vue/cli now also installs 8.0.0 ever since `3.12.0` and `4.0.0-rc4`