### PR TITLE
Feat: prefer sass loader v8

### DIFF
--- a/generator/tools/alaCarte.js
+++ b/generator/tools/alaCarte.js
@@ -1,9 +1,9 @@
 function addDependencies (api) {
   api.extendPackage({
     devDependencies: {
-      "vuetify-loader": "^1.2.2",
-      "sass": "^1.17.4",
-      "sass-loader": "^7.1.0",
+      "vuetify-loader": "^1.3.0",
+      "sass": "^1.19.0",
+      "sass-loader": "^8.0.0",
     }
   })
 }


### PR DESCRIPTION
This can land after: https://github.com/vuetifyjs/vue-cli-plugin-vuetify/pull/122

Newer versions of `@vue/cli` will install version `8.0.0` by default, so we can do it aswell to avoid warnings in the console.

Might be semver minor? I'm not sure since the generator only runs once, so it would only apply for new projects.
