### PR TITLE
fix: include user-defined css loader options

### DIFF
--- a/util/helpers.js
+++ b/util/helpers.js
@@ -50,9 +50,14 @@ function mergeRules (api, opt, ext) {
     sassLoaderVersion = semver.major(require('sass-loader/package.json').version)
   } catch (e) {}
 
+  // Merge with user-defined loader data config
   if (sassLoaderVersion < 8) {
+    if (opt.data) data.unshift(opt.data)
+
     opt.data = data.join('\n')
   } else {
+    if (opt.prependData) data.unshift(opt.prependData)
+
     opt.prependData = data.join('\n')
   }
 


### PR DESCRIPTION
As said in vuetifyjs/vue-cli-plugin-vuetify#128, this plugin shouldn't overwrite sass-loader configuration that's defined in user's `vue.config.js` but instead append its rules to it.